### PR TITLE
Add journal search to overview

### DIFF
--- a/app/components/find-journal.js
+++ b/app/components/find-journal.js
@@ -1,0 +1,29 @@
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+
+export default Component.extend({
+    store: service('store'),
+
+    onSelect: () => { },
+
+    actions: {
+
+        /** Search for journals by matching a term 
+         * 
+         * @param term {string} The search term (regex)
+         * 
+         * TODO:  This simply fetches all journals and iterates through the whole list.
+         * It is not suitable for large numbers of journals.  Instead, the server should provide
+         * a search API.
+        */
+        searchJournals(term) {
+
+            var regex = new RegExp(term, 'i');
+
+            return this.get('store').findAll('journal')
+                .then((journals) => journals.filter(journal => {
+                    return journal.get('name').match(regex);
+                }));
+        }
+    }
+});

--- a/app/components/submission-overview-details.js
+++ b/app/components/submission-overview-details.js
@@ -4,7 +4,9 @@ import { inject as service } from '@ember/service';
 export default Component.extend({
     doiService: service('doi'),
 
-    journal: null,
+    store: service('store'),
+
+    doiJournal: null,
 
     init() {
         this._super(...arguments);
@@ -13,9 +15,25 @@ export default Component.extend({
         if (submission) {
             this.get('doiService').resolve(submission).then(function (doiInfo) {
                 self.set('doiInfo', doiInfo);
+
+                // Search journals for a matching title, for pre-populating purposes
+                // If found, we set the submission's journal to it.  
+                // We also set a property for the journal title, because the json format
+                // uses hyphens, and it's unclear how to access them from .hbs templates
+                self.get('store').findAll('journal')
+                    .then((journals) => journals.find(function (journal) {
+                        var title = journal.get('name');
+                        var doiTitle = doiInfo["container-title"];
+                        return title.trim() === doiTitle.trim();
+                    })).then(function (match) {
+                        var doiInfo = self.get('doiInfo');
+                        self.set('doiJournal', match);
+                        self.set('doiJournalTitle', doiInfo["container-title"]);
+                        submission.set('journal', match);
+                    })
             });
         }
-    }, 
+    },
     actions: {
 
         /** Sets the selected journal for the current submission.
@@ -25,6 +43,6 @@ export default Component.extend({
         selectJournal(journal) {
             var submission = this.get('submission');
             return submission.set('journal', journal);
-        }
+        },
     }
 });

--- a/app/components/submission-overview-details.js
+++ b/app/components/submission-overview-details.js
@@ -4,6 +4,8 @@ import { inject as service } from '@ember/service';
 export default Component.extend({
     doiService: service('doi'),
 
+    journal: null,
+
     init() {
         this._super(...arguments);
         var submission = this.get('submission');
@@ -12,6 +14,17 @@ export default Component.extend({
             this.get('doiService').resolve(submission).then(function (doiInfo) {
                 self.set('doiInfo', doiInfo);
             });
+        }
+    }, 
+    actions: {
+
+        /** Sets the selected journal for the current submission.
+         * 
+         * @param journal {DS.Model} The journal
+         */
+        selectJournal(journal) {
+            var submission = this.get('submission');
+            return submission.set('journal', journal);
         }
     }
 });

--- a/app/templates/components/find-journal.hbs
+++ b/app/templates/components/find-journal.hbs
@@ -1,0 +1,8 @@
+{{#power-select
+  search=(action "searchJournals")
+  selected=value
+  onchange=onSelect
+  as |journal|
+}}
+  {{journal.name}}
+{{/power-select}}

--- a/app/templates/components/submission-overview-details.hbs
+++ b/app/templates/components/submission-overview-details.hbs
@@ -17,7 +17,11 @@
             <label for="journal" class="col-sm-2 col-form-label">Journal:</label>
 
             <div class="col-sm-10">
+                {{#unless doiJournal}}
                 {{find-journal id="journal" class="form-control" onSelect=(action "selectJournal") value=submission.journal}}
+                {{else}}
+                <input type="text" class="form-control" readonly value={{doiJournalTitle}} />
+                {{/unless}}
             </div>
         </div>
     </form>

--- a/app/templates/components/submission-overview-details.hbs
+++ b/app/templates/components/submission-overview-details.hbs
@@ -13,6 +13,13 @@
                     submission.title) value="target.value" }} />
             </div>
         </div>
+        <div class="form-group row">
+            <label for="journal" class="col-sm-2 col-form-label">Journal:</label>
+
+            <div class="col-sm-10">
+                {{find-journal id="journal" class="form-control" onSelect=(action "selectJournal") value=submission.journal}}
+            </div>
+        </div>
     </form>
 </div>
 {{yield}}

--- a/app/templates/components/submission-overview-view.hbs
+++ b/app/templates/components/submission-overview-view.hbs
@@ -10,6 +10,10 @@
                 <th>Title</th>
                 <td>{{submission.title}}</td>
             </tr>
+            <tr>
+                <th>Journal</th>
+                <td>{{submission.journal.name}}</td>
+            </tr>
         </tbody>
     </table>
 </div>

--- a/tests/integration/components/find-journal-test.js
+++ b/tests/integration/components/find-journal-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('find-journal', 'Integration | Component | find journal', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{find-journal}}`);
+
+  assert.ok(this.$());
+
+  // Template block usage:
+  this.render(hbs`
+    {{#find-journal}}
+      template block text
+    {{/find-journal}}
+  `);
+
+  assert.ok(this.$());
+});


### PR DESCRIPTION
# Overview 
* Adds a widget for selecting a journal
* Automatically selects the journal if detected from the DOI

# How to Test
* Check out this PR locally 
  1.  Check out the latest `master` from pass-ember (e.g. `git checkout master` then `git pull`)
  2.  Create a branch from master to try it out in : `git checkout -b birkland-issue-18 master`
  3.  Pull the PR into it `git pull https://github.com/birkland/pass-ember.git issue-18`
  4.  Do `npm install` and then `ember serve`
* Without pre-populating from DOI
   1.  Start a new submission.  Do not enter a DOI.  Click next
   2. Enter in an arbitrary title.  Start typing in the journal search box and select a journal
   3. Click 'save and continue', you should still see the journal in the summary
* With pre-populating a DOI
  1. Start a new submission.  Enter in a viable DOI that resolves to one of our journals, e.g. `10.1039/c7fo01251a`.  Click next
  2. Wait until it pre-populates.  You should see a title appear, and the journal field turn into a read-only selection displaying the journal from the DOI.  
  3. Click 'save and continue', you should still see the journal in the summary

Resolves #18 

Interested parties: @htpvu 