### PR TITLE
Add metadata skeleton

### DIFF
--- a/app/components/submission-metadata-common.js
+++ b/app/components/submission-metadata-common.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/components/submission-metadata-nihms.js
+++ b/app/components/submission-metadata-nihms.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/components/submission-metadata-pages.js
+++ b/app/components/submission-metadata-pages.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/components/submission-metadata-par.js
+++ b/app/components/submission-metadata-par.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/components/workflow-group.js
+++ b/app/components/workflow-group.js
@@ -37,6 +37,16 @@ export default Component.extend({
             }
         },
 
+        back() {
+            var steps = this.get('steps');
+            var step = this.get('step');
+            var i = steps.findIndex((e) => e === step);
+
+            if (i > 0) {
+                this.set('step', steps[i-1]);
+            }
+        },
+
         save() {
             var workflow = this.get('workflow');
             workflow.set('name', this.get('name'));

--- a/app/templates/components/submission-metadata-common.hbs
+++ b/app/templates/components/submission-metadata-common.hbs
@@ -1,0 +1,23 @@
+<h3>Common</h3>
+<p>
+    Here are some instructions
+</p>
+<div class="container">
+    <form>
+        <div class="form-group row">
+            <label for="abstract" class="col-sm-2 col-form-label">Abstract</label>
+
+            <div class="col-sm-10">
+                <textarea id="abstract" rows="4" class="form-control" />
+            </div>
+        </div>
+        <div class="form-group row">
+            <label for="volume" class="col-sm-2 col-form-label">Volume</label>
+
+            <div class="col-sm-10">
+                <input id="volume" type="text" class="form-control" />
+            </div>
+        </div>
+    </form>
+</div>
+{{yield}}

--- a/app/templates/components/submission-metadata-nihms.hbs
+++ b/app/templates/components/submission-metadata-nihms.hbs
@@ -1,0 +1,23 @@
+<h3>NIHMS</h3>
+<p>
+    Input these for NIHMS
+</p>
+<div class="container">
+    <form>
+        <div class="form-group row">
+            <label for="abstract" class="col-sm-2 col-form-label">Abstract</label>
+
+            <div class="col-sm-10">
+                <textarea id="abstract" rows="4" class="form-control" />
+            </div>
+        </div>
+        <div class="form-group row">
+            <label for="volume" class="col-sm-2 col-form-label">Volume</label>
+
+            <div class="col-sm-10">
+                <input id="volume" type="text" class="form-control" />
+            </div>
+        </div>
+    </form>
+</div>
+{{yield}}

--- a/app/templates/components/submission-metadata-pages.hbs
+++ b/app/templates/components/submission-metadata-pages.hbs
@@ -1,0 +1,23 @@
+<h3>PAGES</h3>
+<p>
+    Let's submit to pages
+</p>
+<div class="container">
+    <form>
+        <div class="form-group row">
+            <label for="abstract" class="col-sm-2 col-form-label">Abstract</label>
+
+            <div class="col-sm-10">
+                <textarea id="abstract" rows="4" class="form-control" />
+            </div>
+        </div>
+        <div class="form-group row">
+            <label for="volume" class="col-sm-2 col-form-label">Volume</label>
+
+            <div class="col-sm-10">
+                <input id="volume" type="text" class="form-control" />
+            </div>
+        </div>
+    </form>
+</div>
+{{yield}}

--- a/app/templates/components/submission-metadata-par.hbs
+++ b/app/templates/components/submission-metadata-par.hbs
@@ -1,0 +1,23 @@
+<h3>PAR</h3>
+<p>
+    These are par for the course.
+</p>
+<div class="container">
+    <form>
+        <div class="form-group row">
+            <label for="abstract" class="col-sm-2 col-form-label">Abstract</label>
+
+            <div class="col-sm-10">
+                <textarea id="abstract" rows="4" class="form-control" />
+            </div>
+        </div>
+        <div class="form-group row">
+            <label for="volume" class="col-sm-2 col-form-label">Volume</label>
+
+            <div class="col-sm-10">
+                <input id="volume" type="text" class="form-control" />
+            </div>
+        </div>
+    </form>
+</div>
+{{yield}}

--- a/app/templates/components/workflow-card.hbs
+++ b/app/templates/components/workflow-card.hbs
@@ -7,17 +7,22 @@
     </div>
 
     <div class="row">
-        <div class="col-4">
+        <div class="col-3">
+            {{#if back}}
+            <button class="btn btn-primary btn-small" onclick={{action back}}>Back</button>
+            {{/if}}
+        </div>
+        <div class="col-3">
             {{#if cancel}}
             <button class="btn btn-primary btn-small" onclick={{action cancel}}>Cancel</button>
             {{/if}}
         </div>
-        <div class="col-4">
+        <div class="col-3">
             {{#if save}}
             <button class="btn btn-primary btn-small" onclick={{action save}}>Save</button>
             {{/if}}
         </div>
-        <div class="col-4">
+        <div class="col-3">
             {{#if continue}}
             <button class="btn btn-primary btn-small" onclick={{action continue}}>Save and Continue</button>
             {{/if}}

--- a/app/templates/submission/show/metadata.hbs
+++ b/app/templates/submission/show/metadata.hbs
@@ -1,2 +1,24 @@
-Metadata
-{{outlet}}
+<h2>Submission Metadata</h2>
+{{#workflow-group name="metadata" workflow=(workflow-for model "metadata") as |group|}} 
+    {{#workflow-card step="common" group=group 
+            next=(action "advance" target=group)}}
+        {{submission-metadata-common}}
+    {{/workflow-card}} 
+
+    {{#workflow-card step="nihms" group=group 
+            back=(action "back" target=group)
+            next=(action "advance" target=group)}}
+        {{submission-metadata-nihms}}
+    {{/workflow-card}} 
+
+    {{#workflow-card step="pages" group=group
+            back=(action "back" target=group)
+            next=(action "advance" target=group)}}
+        {{submission-metadata-pages}}
+    {{/workflow-card}} 
+
+    {{#workflow-card step="par" group=group 
+            back=(action "back" target=group)}}
+        {{submission-metadata-par}}
+    {{/workflow-card}} 
+{{/workflow-group}}

--- a/tests/integration/components/submission-metadata-common-test.js
+++ b/tests/integration/components/submission-metadata-common-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('submission-metadata-common', 'Integration | Component | submission metadata common', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{submission-metadata-common}}`);
+
+  assert.ok(this.$());
+
+  // Template block usage:
+  this.render(hbs`
+    {{#submission-metadata-common}}
+      template block text
+    {{/submission-metadata-common}}
+  `);
+
+  assert.ok(this.$());
+});

--- a/tests/integration/components/submission-metadata-nihms-test.js
+++ b/tests/integration/components/submission-metadata-nihms-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('submission-metadata-nihms', 'Integration | Component | submission metadata nihms', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{submission-metadata-nihms}}`);
+
+  assert.ok(this.$());
+
+  // Template block usage:
+  this.render(hbs`
+    {{#submission-metadata-nihms}}
+      template block text
+    {{/submission-metadata-nihms}}
+  `);
+
+  assert.ok(this.$());
+});

--- a/tests/integration/components/submission-metadata-pages-test.js
+++ b/tests/integration/components/submission-metadata-pages-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('submission-metadata-pages', 'Integration | Component | submission metadata pages', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{submission-metadata-pages}}`);
+
+  assert.ok(this.$());
+
+  // Template block usage:
+  this.render(hbs`
+    {{#submission-metadata-pages}}
+      template block text
+    {{/submission-metadata-pages}}
+  `);
+
+  assert.ok(this.$());
+});

--- a/tests/integration/components/submission-metadata-par-test.js
+++ b/tests/integration/components/submission-metadata-par-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('submission-metadata-par', 'Integration | Component | submission metadata par', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{submission-metadata-par}}`);
+
+  assert.ok(this.$());
+
+  // Template block usage:
+  this.render(hbs`
+    {{#submission-metadata-par}}
+      template block text
+    {{/submission-metadata-par}}
+  `);
+
+  assert.ok(this.$());
+});


### PR DESCRIPTION
# Overview
* Adds content to the "metadata" submission step
* Adds components for each type of metadata (common, nihms, pages, par)
* Adds a 'back' button option, uses it to page back and forth through the metadata

# Notes
* HTML for each individual metadata step can be found in `templates/components/submission-metadata-{name}.hbs`.  Each one has some default/example forms

# How to Test
* Check out this PR locally 
  1.  Check out the latest `master` from pass-ember (e.g. `git checkout master` then `git pull`)
  2.  Create a branch from master to try it out in : `git checkout -b birkland-issue-49 master`
  3.  Pull the PR into it `git pull https://github.com/birkland/pass-ember.git issue-49`
  4.  Do `npm install` and then `ember serve`
* Create a new submission. 
   1. Feel free to click past the DOI and journal/title pages and leave them blank; click save and continue
   2. Use the side navigation to select `Metadata`.  Use the back and next buttons to page through.

Resolves #49