### PR TITLE
Submission navigation updates

### DIFF
--- a/app/templates/grants/show.hbs
+++ b/app/templates/grants/show.hbs
@@ -66,7 +66,7 @@
                 (action "attachWorkflow" newSubmissionObject target=group)
                 (action "saveAndLinkGrant")
                 (action (mut isShowingForm) false)
-                (route-action "transitionTo" "submission.show.index" newSubmissionObject)
+                (route-action "transitionTo" "submission.show.funding" newSubmissionObject)
             ))}}
           {{submission-overview-details submission=newSubmissionObject}}
         {{/workflow-card}}

--- a/app/templates/grants/show.hbs
+++ b/app/templates/grants/show.hbs
@@ -52,6 +52,7 @@
         {{/workflow-card}}
 
         {{#workflow-card step="details" group=group
+            back=(action "back" target=group)
             cancel=(action (queue
                 (action (invoke "rollbackAttributes" model))
                 (action (mut isShowingForm) false)

--- a/app/templates/submission/new.hbs
+++ b/app/templates/submission/new.hbs
@@ -10,9 +10,17 @@
         {{/workflow-card}}
       
         {{#workflow-card step="details" group=group
+            back=(action "back" target=group)
             cancel=(action (queue 
                 (action (invoke "rollbackAttributes" model)) 
                 (route-action "back")
+            ))
+            save=(action (queue
+                (action (invoke "save" model))
+                (route-action "transitionTo" "submission.show.funding" model)
+                (action "save" target=group)
+                (action "attachWorkflow" model target=group)
+                (action (invoke "save" model))
             ))
             continue=(action (queue
                 (action (invoke "save" model))

--- a/app/templates/submission/new.hbs
+++ b/app/templates/submission/new.hbs
@@ -15,6 +15,7 @@
                 (route-action "back")
             ))
             continue=(action (queue
+                (action (invoke "save" model))
                 (route-action "transitionTo" "submission.show.funding" model)
                 (action "advance" target=group)
                 (action "save" target=group)

--- a/app/templates/submission/new.hbs
+++ b/app/templates/submission/new.hbs
@@ -15,11 +15,11 @@
                 (route-action "back")
             ))
             continue=(action (queue
+                (route-action "transitionTo" "submission.show.funding" model)
                 (action "advance" target=group)
                 (action "save" target=group)
                 (action "attachWorkflow" model target=group)
                 (action (invoke "save" model))
-                (route-action "transitionTo" "submission.show.index" model)
             ))}}
           {{submission-overview-details submission=model}}
         {{/workflow-card}}

--- a/app/templates/submission/show/funding.hbs
+++ b/app/templates/submission/show/funding.hbs
@@ -5,6 +5,7 @@
         cancel=(action "rollback") 
         save=(action "saveAll")
         continue=(action (queue
+            (route-action "transitionTo" "submission.show.compliance" model)
             (action "advance" target=group)
             (action "save" target=group)
             (action "attachWorkflow" model target=group)

--- a/app/templates/submission/show/funding.hbs
+++ b/app/templates/submission/show/funding.hbs
@@ -2,6 +2,7 @@
 
 {{#workflow-group name="funding" workflow=(workflow-for model "funding") as |group|}} 
     {{#workflow-card step="select-funders" group=group
+        back=(route-action "transitionTo" "submission.show.index" model)
         cancel=(action "rollback") 
         save=(action "saveAll")
         continue=(action (queue
@@ -31,7 +32,8 @@
         </div>
     {{/workflow-card}} 
 
-    {{#workflow-card step="view" group=group 
+    {{#workflow-card step="view" group=group
+        back=(route-action "transitionTo" "submission.show.index" model)
         next=(route-action "transitionTo" "submission.show.compliance" model)}}
         {{submission-funding-table grants=model.grants}}
     {{/workflow-card}} 

--- a/app/templates/submission/show/index.hbs
+++ b/app/templates/submission/show/index.hbs
@@ -17,6 +17,7 @@
         {{/workflow-card}}
       
         {{#workflow-card step="details" group=group
+            back=(action "back" target=group)
             cancel=(action (queue 
                 (action (invoke "rollbackAttributes" model)) 
             )) 

--- a/app/templates/submission/show/index.hbs
+++ b/app/templates/submission/show/index.hbs
@@ -25,6 +25,7 @@
                 (action (invoke "save" model))
             ))
             continue=(action (queue
+                (route-action "transitionTo" "submission.show.funding" model)
                 (action "advance" target=group)
                 (action "save" target=group)
                 (action (invoke "save" model))


### PR DESCRIPTION
# Overview
* Transitions directly to next submission step upon `Save and Continue`, instead of the 'review' card
* Adds a 'back' button where appropriate to overview and funding steps
  * This pattern will be carried forward as 'compliance' and 'metadata', etc go live

# How to test
* Check out this PR locally 
  1.  Check out the latest `master` from pass-ember (e.g. `git checkout master` then `git pull`)
  2.  Create a branch from master to try it out in : `git checkout -b birkland-issue-47 master`
  3.  Pull the PR into it `git pull https://github.com/birkland/pass-ember.git issue-47`
  4.  Do `npm install` and then `ember serve`
* Create a new submission via the grants table
  * After clicking 'next' on the DOI stage, you now see a 'back' button that will allow you to go back to DOI entry
    * Note:  the DOI auto-population of title/journal only happens if the fields are empty.  So if you entered a DOI, clicked next, watched it auto-fill, then went back and changed the DOI, it won't change the title and journal 
  * Click `Save and Continue`.  You should now go directly to the funding step
  * If you click `back` at this stage, you'll see the submission overview.  If you click 'next', back to funding
* Create a submission via the submissions table
  * This is pretty much the same as the above.  Notice the `Save and Continue" transitions directly to funding.

Interested parties @htpvu

Resolves #47 