### PR TITLE
Added UI element to attachment page template

### DIFF
--- a/app/templates/submission/show/attachments.hbs
+++ b/app/templates/submission/show/attachments.hbs
@@ -1,2 +1,93 @@
-Attachments
-{{outlet}}
+<h3>Submission attachment</h3>
+
+{{#workflow-group name="attachments" workflow=(workflow-for model "attachments") as |group|}}
+    {{#workflow-card step="upload" group=group
+            back=(route-action "transitionTo" "submission.show.metadata" model)
+            continue=(route-action "transitionTo" "submission.show.submission" model)}}
+
+
+            <p>
+                Attaching manuscript/article files to this submission.
+            </p>
+            <div class="container">
+                <form>
+                    <div class="form-group row">
+                        <label for="file1" class="col-sm-2 col-form-label">File to upload</label>
+                        <div class="col-sm-5">
+                            <label for="file1description" class="col-form-label">Description</label>
+                            <input id="file1description" type="text" class="form-control" />
+                        </div>
+                        <div class="col-sm-5">
+                          <label for="file1" class="col-form-label">Location</label>
+                          <label class="custom-file">
+                                <input type="file" id="file1" class="custom-file-input">
+                                <span class="custom-file-control"></span>
+                          </label>
+                        </div>
+                    </div>
+                    <div class="form-group row">
+                        <label for="file2" class="col-sm-2 col-form-label">File to upload</label>
+                        <div class="col-sm-5">
+                            <label for="file2description" class="col-form-label">Description</label>
+                            <input id="file2description" type="text" class="form-control" />
+                        </div>
+                        <div class="col-sm-5">
+                          <label for="file2" class="col-form-label">Location</label>
+                          <label class="custom-file">
+                                <input type="file" id="file2" class="custom-file-input">
+                                <span class="custom-file-control"></span>
+                          </label>
+                        </div>
+                    </div>
+                    <div class="form-group row">
+                        <label for="file3" class="col-sm-2 col-form-label">File to upload</label>
+                        <div class="col-sm-5">
+                            <label for="file3description" class="col-form-label">Description</label>
+                            <input id="file3description" type="text" class="form-control" />
+                        </div>
+                        <div class="col-sm-5">
+                          <label for="file3" class="col-form-label">Location</label>
+                          <label class="custom-file">
+                                <input type="file" id="file3" class="custom-file-input">
+                                <span class="custom-file-control"></span>
+                          </label>
+                        </div>
+                    </div>
+                    <div class="form-group row">
+                        <label for="file4" class="col-sm-2 col-form-label">File to upload</label>
+                        <div class="col-sm-5">
+                            <label for="file4description" class="col-form-label">Description</label>
+                            <input id="file4description" type="text" class="form-control" />
+                        </div>
+                        <div class="col-sm-5">
+                          <label for="file4" class="col-form-label">Location</label>
+                          <label class="custom-file">
+                                <input type="file" id="file4" class="custom-file-input">
+                                <span class="custom-file-control"></span>
+                          </label>
+                        </div>
+                    </div>
+                    <div class="form-group row">
+                        <label for="file5" class="col-sm-2 col-form-label">File to upload</label>
+                        <div class="col-sm-5">
+                            <label for="file5description" class="col-form-label">Description</label>
+                            <input id="file5description" type="text" class="form-control" />
+                        </div>
+                        <div class="col-sm-5">
+                          <label for="file5" class="col-form-label">Location</label>
+                          <label class="custom-file">
+                                <input type="file" id="file5" class="custom-file-input">
+                                <span class="custom-file-control"></span>
+                          </label>
+                        </div>
+                    </div>
+                    <div class="form-group row">
+                        <div class="col-sm-12">
+                            <button type="button" class="btn btn-secondary float-right btn-sm">Add more files</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+
+    {{/workflow-card}}
+{{/workflow-group}}


### PR DESCRIPTION
# Overview 
* Added input elements to "Attachments" page
* Added back/next navigation buttons to the "Attachments" page

# How to Test
* Without pre-populating from DOI
   1.  Start a new submission. Click "next" until left handside nav bar appears
   2. Go to "Attachments" section
   3. Click "Next" and "Back" to advance/go back in the workflow
Resolves #69

Interested parties: @birkland  