### PR TITLE
Issue 62 - Layout issue on the submission's journal selection modal pop up 

### DIFF
--- a/app/templates/components/workflow-card.hbs
+++ b/app/templates/components/workflow-card.hbs
@@ -6,28 +6,22 @@
         </div>
     </div>
 
-    <div class="row">
-        <div class="col-3">
-            {{#if back}}
-            <button class="btn btn-primary btn-small" onclick={{action back}}>Back</button>
-            {{/if}}
-        </div>
-        <div class="col-3">
-            {{#if cancel}}
-            <button class="btn btn-primary btn-small" onclick={{action cancel}}>Cancel</button>
-            {{/if}}
-        </div>
-        <div class="col-3">
-            {{#if save}}
-            <button class="btn btn-primary btn-small" onclick={{action save}}>Save</button>
-            {{/if}}
-        </div>
-        <div class="col-3">
+    <div class="btn-toolbar float-right">
+        {{#if back}}
+        <button class="btn btn-primary btn-small mr-3 my-1" onclick={{action back}}>Back</button>
+        {{/if}}
+        {{#if cancel}}
+        <button class="btn btn-primary btn-small mr-3 my-1" onclick={{action cancel}}>Cancel</button>
+        {{/if}}
+        {{#if save}}
+        <button class="btn btn-primary btn-small mr-3 my-1" onclick={{action save}}>Save</button>
+        {{/if}}
+        <div class="btn-group" role="group" aria-label="Proceed button group">
             {{#if continue}}
-            <button class="btn btn-primary btn-small" onclick={{action continue}}>Save and Continue</button>
+            <button class="btn btn-primary btn-small my-1" onclick={{action continue}}>Save and Continue</button>
             {{/if}}
             {{#if next}}
-            <button class="btn btn-primary btn-small" onclick={{action next}}>Next</button>
+            <button class="btn btn-primary btn-small my-1" onclick={{action next}}>Next</button>
             {{/if}}
         </div>
     </div>

--- a/app/templates/components/workflow-card.hbs
+++ b/app/templates/components/workflow-card.hbs
@@ -6,23 +6,25 @@
         </div>
     </div>
 
-    <div class="btn-toolbar float-right">
-        {{#if back}}
-        <button class="btn btn-primary btn-small mr-3 my-1" onclick={{action back}}>Back</button>
-        {{/if}}
-        {{#if cancel}}
-        <button class="btn btn-primary btn-small mr-3 my-1" onclick={{action cancel}}>Cancel</button>
-        {{/if}}
-        {{#if save}}
-        <button class="btn btn-primary btn-small mr-3 my-1" onclick={{action save}}>Save</button>
-        {{/if}}
-        <div class="btn-group" role="group" aria-label="Proceed button group">
-            {{#if continue}}
-            <button class="btn btn-primary btn-small my-1" onclick={{action continue}}>Save and Continue</button>
+    <div class="row">
+        <div class="btn-toolbar ml-auto">
+            {{#if back}}
+            <button class="btn btn-primary btn-small mr-3 my-1" onclick={{action back}}>Back</button>
             {{/if}}
-            {{#if next}}
-            <button class="btn btn-primary btn-small my-1" onclick={{action next}}>Next</button>
+            {{#if cancel}}
+            <button class="btn btn-primary btn-small mr-3 my-1" onclick={{action cancel}}>Cancel</button>
             {{/if}}
+            {{#if save}}
+            <button class="btn btn-primary btn-small mr-3 my-1" onclick={{action save}}>Save</button>
+            {{/if}}
+            <div class="btn-group" role="group" aria-label="Proceed button group">
+                {{#if continue}}
+                <button class="btn btn-primary btn-small my-1" onclick={{action continue}}>Save and Continue</button>
+                {{/if}}
+                {{#if next}}
+                <button class="btn btn-primary btn-small my-1" onclick={{action next}}>Next</button>
+                {{/if}}
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Submission workflow buttons re-organized. New buttons are placed at the bottom, as before, but the button toolbar no longer takes up the full width of the component. Any buttons that would overflow the component now break onto a new line. 

These changes apply to buttons:
* View Submissions > Create new Submission workflow
* View Submissions > click an award number > New Submission modal that pops up
* Submission details > Overview, Awards, Metadata, Attachments sections

Examples of new button behavior shown below:

![pass-btn-lg](https://user-images.githubusercontent.com/5167587/33844364-22025b0e-de6e-11e7-9727-d29374a7d14a.png)

![pass-btn-sm](https://user-images.githubusercontent.com/5167587/33844375-259b16c0-de6e-11e7-82d0-5e973b2b92eb.png)

![image](https://user-images.githubusercontent.com/5167587/33844601-bcd66c92-de6e-11e7-9caf-87b9bc389e46.png)


