### PR TITLE
Filter out unneeded metadata forms based on deposits

### DIFF
--- a/app/components/workflow-group.js
+++ b/app/components/workflow-group.js
@@ -22,7 +22,17 @@ export default Component.extend({
     },
 
     addStep(step) {
+        let filter = this.get('stepFilter');
+        
+        if (filter) {
+            if (!filter(step)) {
+                console.log('NOT adding step ' + name);
+                return;
+            }
+        }
+        
         console.log("Adding step " + step);
+
         this.get('steps').push(step);
 
         if (!this.get('step')) {

--- a/app/components/workflow-group.js
+++ b/app/components/workflow-group.js
@@ -9,16 +9,20 @@ export default Component.extend({
 
     init() {
         this._super(...arguments)
+        this.set('steps', []);
         var workflow = this.get('workflow');
         if (!workflow) {
+            console.log("No workflow");
            this.set('workflow', this.get('store').createRecord('workflow'));
         } else {
+            console.log("Opening existing workflow " + workflow.get('name') );
             this.set('steps', workflow.get('steps').split(','));
             this.set('step', workflow.get('step'));
         }
     },
 
     addStep(step) {
+        console.log("Adding step " + step);
         this.get('steps').push(step);
 
         if (!this.get('step')) {
@@ -30,11 +34,14 @@ export default Component.extend({
         advance() {
             var steps = this.get('steps');
             var step = this.get('step');
+            console.log("Steps are: " + steps);
             var i = steps.findIndex((e) => e === step);
+            console.log("Current step " + step + " is at: " + i);
 
             if (steps[i+1]) {
                 this.set('step', steps[i+1]);
             }
+            console.log("After advance, at step " + this.get('step') + " :" + (i+1));
         },
 
         back(self) {
@@ -45,6 +52,7 @@ export default Component.extend({
             if (i > 0) {
                 this.set('step', steps[i-1]);
             }
+            console.log("After back, at step " + this.get('step') + " :" + (i-1));
         },
 
         save() {
@@ -66,11 +74,24 @@ export default Component.extend({
         },
 
         nextActionFor(step) {
-            this.get('actions').advance.call(this);
+            var steps = this.get('steps');
+            if (steps.indexOf(step) === (steps.length - 1)) {
+                console.log("This is last, so going down...");
+                this.get('last')();
+            } else {
+                console.log("not last, so going forward");
+                this.get('actions').advance.call(this);
+            }
         },
 
         backActionFor(step) {
-            this.get('actions').advance.call(this);
+            if (this.get('steps').indexOf(step) === 0) {
+                console.log("This is first, so going up...")
+                this.get('first')();
+            } else {
+                console.log("not first, so going back");
+                this.get('actions').back.call(this);
+            }
         },
     }
 });

--- a/app/components/workflow-group.js
+++ b/app/components/workflow-group.js
@@ -12,10 +12,8 @@ export default Component.extend({
         this.set('steps', []);
         var workflow = this.get('workflow');
         if (!workflow) {
-            console.log("No workflow");
            this.set('workflow', this.get('store').createRecord('workflow'));
         } else {
-            console.log("Opening existing workflow " + workflow.get('name') );
             this.set('steps', workflow.get('steps').split(','));
             this.set('step', workflow.get('step'));
         }
@@ -26,12 +24,9 @@ export default Component.extend({
         
         if (filter) {
             if (!filter(step)) {
-                console.log('NOT adding step ' + name);
                 return;
             }
         }
-        
-        console.log("Adding step " + step);
 
         this.get('steps').push(step);
 
@@ -44,17 +39,14 @@ export default Component.extend({
         advance() {
             var steps = this.get('steps');
             var step = this.get('step');
-            console.log("Steps are: " + steps);
             var i = steps.findIndex((e) => e === step);
-            console.log("Current step " + step + " is at: " + i);
 
             if (steps[i+1]) {
                 this.set('step', steps[i+1]);
             }
-            console.log("After advance, at step " + this.get('step') + " :" + (i+1));
         },
 
-        back(self) {
+        back() {
             var steps = this.get('steps');
             var step = this.get('step');
             var i = steps.findIndex((e) => e === step);
@@ -62,7 +54,6 @@ export default Component.extend({
             if (i > 0) {
                 this.set('step', steps[i-1]);
             }
-            console.log("After back, at step " + this.get('step') + " :" + (i-1));
         },
 
         save() {
@@ -86,20 +77,16 @@ export default Component.extend({
         nextActionFor(step) {
             var steps = this.get('steps');
             if (steps.indexOf(step) === (steps.length - 1)) {
-                console.log("This is last, so going down...");
                 this.get('last')();
             } else {
-                console.log("not last, so going forward");
                 this.get('actions').advance.call(this);
             }
         },
 
         backActionFor(step) {
             if (this.get('steps').indexOf(step) === 0) {
-                console.log("This is first, so going up...")
                 this.get('first')();
             } else {
-                console.log("not first, so going back");
                 this.get('actions').back.call(this);
             }
         },

--- a/app/components/workflow-group.js
+++ b/app/components/workflow-group.js
@@ -37,7 +37,7 @@ export default Component.extend({
             }
         },
 
-        back() {
+        back(self) {
             var steps = this.get('steps');
             var step = this.get('step');
             var i = steps.findIndex((e) => e === step);
@@ -63,6 +63,14 @@ export default Component.extend({
             } else {
                 target.get('workflows').pushObject(this.get('workflow'));
             }
+        },
+
+        nextActionFor(step) {
+            this.get('actions').advance.call(this);
+        },
+
+        backActionFor(step) {
+            this.get('actions').advance.call(this);
         },
     }
 });

--- a/app/controllers/submission/show/metadata.js
+++ b/app/controllers/submission/show/metadata.js
@@ -1,0 +1,22 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+
+    actions: {
+        filterWorkflowStep(name) {
+            let submission = this.get('model');
+            var repos = submission.get('deposits').map(deposit => deposit.get('repo'));
+            console.log('repos are ' + repos);
+
+            if (name === 'common' && repos.length) {
+                console.log("allowing " + name);
+                return name;
+            } else if (repos.includes(name)) {
+                console.log("allowing " + name);
+                return name;
+            }
+
+            console.log("NOT allowing " + name);
+        }
+    }
+});

--- a/app/controllers/submission/show/metadata.js
+++ b/app/controllers/submission/show/metadata.js
@@ -6,17 +6,12 @@ export default Controller.extend({
         filterWorkflowStep(name) {
             let submission = this.get('model');
             var repos = submission.get('deposits').map(deposit => deposit.get('repo'));
-            console.log('repos are ' + repos);
 
             if (name === 'common' && repos.length) {
-                console.log("allowing " + name);
                 return name;
             } else if (repos.includes(name)) {
-                console.log("allowing " + name);
                 return name;
             }
-
-            console.log("NOT allowing " + name);
         }
     }
 });

--- a/app/helpers/workflow-for.js
+++ b/app/helpers/workflow-for.js
@@ -3,6 +3,8 @@ import { helper } from '@ember/component/helper';
 export function workflowFor([obj, name]) {
   var workflows = obj.get('workflows');
   if (workflows) {
+    console.log("Existing workflows " + workflows.map(wf => wf.get('name')));
+    console.log("Will return workflow " + workflows.find((wf) => wf.get('name') === name));
     return workflows.find((wf) => wf.get('name') === name);
   }
 }

--- a/app/helpers/workflow-for.js
+++ b/app/helpers/workflow-for.js
@@ -3,8 +3,6 @@ import { helper } from '@ember/component/helper';
 export function workflowFor([obj, name]) {
   var workflows = obj.get('workflows');
   if (workflows) {
-    console.log("Existing workflows " + workflows.map(wf => wf.get('name')));
-    console.log("Will return workflow " + workflows.find((wf) => wf.get('name') === name));
     return workflows.find((wf) => wf.get('name') === name);
   }
 }

--- a/app/templates/submission/show/metadata.hbs
+++ b/app/templates/submission/show/metadata.hbs
@@ -1,7 +1,7 @@
 <h2>Submission Metadata</h2>
 {{#workflow-group name="metadata" workflow=(workflow-for model "metadata")
-        up=(route-action "transitionTo" "submission.show.repositories" model)
-        down=(route-action "transitionTo" "submission.show.attachments" model)
+        first=(route-action "transitionTo" "submission.show.repositories" model)
+        last=(route-action "transitionTo" "submission.show.attachments" model)
         as |group|}} 
     {{#workflow-card step="common" group=group
             back=(action "backActionFor" "common" target=group)
@@ -10,20 +10,20 @@
     {{/workflow-card}} 
 
     {{#workflow-card step="nihms" group=group 
-            back=(action "backActionFor" "common" target=group)
-            next=(action "nextActionFor" "common" target=group)}}
+            back=(action "backActionFor" "nihms" target=group)
+            next=(action "nextActionFor" "nihms" target=group)}}
         {{submission-metadata-nihms}}
     {{/workflow-card}} 
 
     {{#workflow-card step="pages" group=group
-            back=(action "backActionFor" "common" target=group)
-            next=(action "nextActionFor" "common" target=group)}}
+            back=(action "backActionFor" "pages" target=group)
+            next=(action "nextActionFor" "pages" target=group)}}
         {{submission-metadata-pages}}
     {{/workflow-card}} 
 
     {{#workflow-card step="par" group=group 
-            back=(action "backActionFor" "common" target=group)
-            next=(action "nextActionFor" "common" target=group)}}
+            back=(action "backActionFor" "par" target=group)
+            next=(action "nextActionFor" "par" target=group)}}
         {{submission-metadata-par}}
     {{/workflow-card}} 
 {{/workflow-group}}

--- a/app/templates/submission/show/metadata.hbs
+++ b/app/templates/submission/show/metadata.hbs
@@ -1,26 +1,29 @@
 <h2>Submission Metadata</h2>
-{{#workflow-group name="metadata" workflow=(workflow-for model "metadata") as |group|}} 
+{{#workflow-group name="metadata" workflow=(workflow-for model "metadata")
+        up=(route-action "transitionTo" "submission.show.repositories" model)
+        down=(route-action "transitionTo" "submission.show.attachments" model)
+        as |group|}} 
     {{#workflow-card step="common" group=group
-            back=(route-action "transitionTo" "submission.show.repositories" model)
-            next=(action "advance" target=group)}}
+            back=(action "backActionFor" "common" target=group)
+            next=(action "nextActionFor" "common" target=group)}}
         {{submission-metadata-common}}
     {{/workflow-card}} 
 
     {{#workflow-card step="nihms" group=group 
-            back=(action "back" target=group)
-            next=(action "advance" target=group)}}
+            back=(action "backActionFor" "common" target=group)
+            next=(action "nextActionFor" "common" target=group)}}
         {{submission-metadata-nihms}}
     {{/workflow-card}} 
 
     {{#workflow-card step="pages" group=group
-            back=(action "back" target=group)
-            next=(action "advance" target=group)}}
+            back=(action "backActionFor" "common" target=group)
+            next=(action "nextActionFor" "common" target=group)}}
         {{submission-metadata-pages}}
     {{/workflow-card}} 
 
     {{#workflow-card step="par" group=group 
-            back=(action "back" target=group)
-            next=(route-action "transitionTo" "submission.show.attachments" model)}}
+            back=(action "backActionFor" "common" target=group)
+            next=(action "nextActionFor" "common" target=group)}}
         {{submission-metadata-par}}
     {{/workflow-card}} 
 {{/workflow-group}}

--- a/app/templates/submission/show/metadata.hbs
+++ b/app/templates/submission/show/metadata.hbs
@@ -2,6 +2,7 @@
 {{#workflow-group name="metadata" workflow=(workflow-for model "metadata")
         first=(route-action "transitionTo" "submission.show.repositories" model)
         last=(route-action "transitionTo" "submission.show.attachments" model)
+        stepFilter=(action "filterWorkflowStep")
         as |group|}} 
     {{#workflow-card step="common" group=group
             back=(action "backActionFor" "common" target=group)
@@ -9,21 +10,21 @@
         {{submission-metadata-common}}
     {{/workflow-card}} 
 
-    {{#workflow-card step="nihms" group=group 
-            back=(action "backActionFor" "nihms" target=group)
-            next=(action "nextActionFor" "nihms" target=group)}}
+    {{#workflow-card step="PMC" group=group 
+            back=(action "backActionFor" "PMC" target=group)
+            next=(action "nextActionFor" "PMC" target=group)}}
         {{submission-metadata-nihms}}
     {{/workflow-card}} 
 
-    {{#workflow-card step="pages" group=group
-            back=(action "backActionFor" "pages" target=group)
-            next=(action "nextActionFor" "pages" target=group)}}
+    {{#workflow-card step="DOE-PAGES" group=group
+            back=(action "backActionFor" "DOE-PAGES" target=group)
+            next=(action "nextActionFor" "DOE-PAGES" target=group)}}
         {{submission-metadata-pages}}
     {{/workflow-card}} 
 
-    {{#workflow-card step="par" group=group 
-            back=(action "backActionFor" "par" target=group)
-            next=(action "nextActionFor" "par" target=group)}}
+    {{#workflow-card step="NSF-PAR" group=group 
+            back=(action "backActionFor" "NSF-PAR" target=group)
+            next=(action "nextActionFor" "NSF-PAR" target=group)}}
         {{submission-metadata-par}}
     {{/workflow-card}} 
 {{/workflow-group}}

--- a/tests/unit/controllers/submission/show/metadata-test.js
+++ b/tests/unit/controllers/submission/show/metadata-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:submission/show/metadata', 'Unit | Controller | submission/show/metadata', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});


### PR DESCRIPTION
# Overview
* Shows _only_ those metadata forms required by the current selection of deposit repositories.  If that list changes, the selection of metadata forms will change.
* Navigation buttons will navigate between metadata forms, or transition to a different submission step (in the case of back on the first MD form, next on the last MD form),

# How to test
* Check out this PR locally 
  1.  Check out the latest `master` from pass-ember (e.g. `git checkout master` then `git pull`)
  2.  Create a branch from master to try it out in : `git checkout -b birkland-issue-79 master`
  3.  Pull the PR into it `git pull https://github.com/birkland/pass-ember.git issue-79`
  4.  Do `npm install` and then `ember serve`
* Do things that change the repository list, and verify that the metadata is pertinent.  There are too many ways to do this to describe.
  * For example, add a NIH grant with no journal defined (should see metadata for NIHMS, since deposit required).  Then add a type 'A' journal, navigate back to metadata and see nothing there.
  * For example, manually add a desired repo (like DOE-pages).  
* Navigate forward/back and see the terminal transitions in the metadata step.

Interested parties: @htpvu 

Resolves: #79 