### PR TITLE
Implement Send button for submissions (issue 54)

### DIFF
--- a/app/controllers/submission/show/submission.js
+++ b/app/controllers/submission/show/submission.js
@@ -1,10 +1,28 @@
 import Controller from '@ember/controller';
 
+// Set these values to specify the server to which the submission POST is made.
+var URL  = 'http://128.84.9.164'
+var PORT = 7000
+
 export default Controller.extend({
     actions: {
-
-        /** Send the submission! */
+        
+        // POST to the server to initiate the FTP operation
         doSend() {
+            var fullURL = encodeURI(URL + ":" + PORT)
+            
+            fetch(fullURL, {
+                method: 'POST'
+            }).then(function(response) {
+                if (response.ok) {
+                    // Command succeeded
+                    console.log("command passed")
+                } else {
+                    // Command failed
+                    console.log("command failed")
+                }
+            });
+                  
             this.set('isSent', true);
         }
     }

--- a/app/controllers/submission/show/submission.js
+++ b/app/controllers/submission/show/submission.js
@@ -16,10 +16,8 @@ export default Controller.extend({
             }).then(function(response) {
                 if (response.ok) {
                     // Command succeeded
-                    console.log("command passed")
                 } else {
                     // Command failed
-                    console.log("command failed")
                 }
             });
                   


### PR DESCRIPTION
When the Send button of the Submission details page is clicked, a POST
is now made to the URL and port specified in submission.js.  The code
recognizes the OK/fail code that is returned by the CGI server from the
command it has executed (for PASS, this is an FTP operation).

Note that if the initial version of the CGI server is used, the command
will be executed but the return value will not be recognized.  This is
because that version of the server does not allow responses to be sent
for POST requests.  A pull request will be made for an updated version
of the CGI script that is allowed to reply to all requestors, among
other changes.  This may not be the most desirable behavior in the long
term, nor the only possible solution to this problem, but it is needed
at this time.

Resolves #54 