### PR TITLE
Issue 96 : UI text changes

### DIFF
--- a/app/helpers/repo-name.js
+++ b/app/helpers/repo-name.js
@@ -1,0 +1,18 @@
+import { helper } from '@ember/component/helper';
+
+export function repoName([repo]) {
+  let repoMap = {
+    "PMC": "PubMed Central",
+    "NSF-PAR": "National Science Foundation Public Access Repository",
+    "DOE-PAGES": "DOE-PAGES",
+    "JHU-IR": "JScholarship - JHU Publications Repository"
+  };
+
+  if (typeof repo !== 'string' || !repoMap.hasOwnProperty(repo)) {
+    return '';
+  }
+
+  return repoMap[repo];
+}
+
+export default helper(repoName);

--- a/app/helpers/repo-name.js
+++ b/app/helpers/repo-name.js
@@ -4,15 +4,14 @@ export function repoName([repo]) {
   let repoMap = {
     "PMC": "PubMed Central",
     "NSF-PAR": "National Science Foundation Public Access Repository",
-    "DOE-PAGES": "DOE-PAGES",
     "JHU-IR": "JScholarship - JHU Publications Repository"
   };
 
-  if (typeof repo !== 'string' || !repoMap.hasOwnProperty(repo)) {
+  if (typeof repo !== 'string') {
     return '';
   }
 
-  return repoMap[repo];
+  return repoMap[repo] || repo;
 }
 
 export default helper(repoName);

--- a/app/templates/submission/show/repositories.hbs
+++ b/app/templates/submission/show/repositories.hbs
@@ -16,7 +16,7 @@ at this time.
             <ul class="list-group">
             {{#each model.deposits as |deposit|}}
                 <li class="list-group-item d-flex justify-content-between align-items-center my-1">
-                    {{deposit.repo}}
+                    {{repo-namedeposit.repo}}
                     <span class="badge badge-primary badge-pill">{{deposit.status}}</span>
                 </li>
             {{/each}}
@@ -29,7 +29,7 @@ at this time.
                     </button>
                     <div class="dropdown-menu" aria-labelledby="addRepo">
                     {{#each remainingRepos as |repo|}}
-                        <button class="dropdown-item" type="button" {{action "addRepo" repo}}>{{repo}}</button>
+                        <button class="dropdown-item" type="button" {{action "addRepo" repo}}>{{repo-name repo}}</button>
                     {{/each}}
                     </div>
                     {{/if}}

--- a/app/templates/submission/show/repositories.hbs
+++ b/app/templates/submission/show/repositories.hbs
@@ -16,7 +16,7 @@ at this time.
             <ul class="list-group">
             {{#each model.deposits as |deposit|}}
                 <li class="list-group-item d-flex justify-content-between align-items-center my-1">
-                    {{repo-namedeposit.repo}}
+                    {{repo-name deposit.repo}}
                     <span class="badge badge-primary badge-pill">{{deposit.status}}</span>
                 </li>
             {{/each}}


### PR DESCRIPTION
Resolves issue #96, changing text in the new submission workflow section where a user selects repositories. A Handlebars helper was added and used to translate the repository acronyms used in the demo data to the desired text.

### Testing
Go through the new submission workflow:
* From home page, click Submissions > Create new Submission (button) OR from either _Grants_ or _Submissions_ pages, click any award number > New Submission (button)
* _Next > Save and Continue_ Click through until you get to Submission Details page. Add awards here if you want.
* _Save and Continue_ to get to Compliance section. If awards were added to this submission, any relevant compliance statements will appear here.
* _Save and Continue_ to get to Repositories section. Text changes are seen here. For each compliance statement seen previously, the relevant repository will already appear here with the modified text. The drop down to add more repositories also have the modified text.

The general workflow should be identical to the previous version of the demo.

Interested parties: @htpvu @birkland 