### PR TITLE
Inspect window.location for api host if none given

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,7 +1,32 @@
 import ENV from 'pass-ember/config/environment';
 import Fedora1Adapter from './fedora1';
 
+function getPort() {
+  if (!ENV.api.port) {
+    return window.location.port;
+  } else {
+    return ENV.api.port;
+  }
+}
+
+function getHost() {
+  // HACK - ENV.api.host is given default values in 
+  // config/environment.js (i.e. it's not null).  If we
+  // detect it's using defaults, then attempt to look at
+  // the request to see if it's using a different host.
+  // THIS IS A HACK FOR THE DEMO, TO WORK AROUND THE FACT
+  // THAT IT DOES NOT USE DNS, AND THE FEDORA HOST IS NOT KNOWN
+  // A-PRIORI, SO CANNOT BE PROVIDED IN AN ENV VARIABLE
+  if (ENV.api.host === 'http://localhost:8080') {
+    return window.location.protocol + "//" +
+      window.location.hostname + ":" + 
+      getPort();
+  } else {
+    return ENV.api.host;
+  }
+}
+
 export default Fedora1Adapter.extend({
-  host: ENV.api.host,
+  host: getHost(),
   namespace: ENV.api.namespace
 });

--- a/config/environment.js
+++ b/config/environment.js
@@ -45,6 +45,10 @@ module.exports = function(environment) {
     ENV.api.host = process.env.PASS_FEDORA_HOST;
   }
 
+  if (process.env.PASS_FEDORA_PORT) {
+    ENV.api.port = process.env.PASS_FEDORA_PORT;
+  }
+
   if (process.env.PASS_FEDORA_PATH) {
     ENV.api.namespace = process.env.PASS_FEDORA_PATH;
   }


### PR DESCRIPTION
Currently, the ember app looks for an environment variable `PASS_FEDORA_HOST`.
If this is not given, then inspect `window.location` for host, protocol, and port.
This is useful in situations where the specific identity Fedora host is not known
 ahead of time, but is known to be on the same host as ember

/cc @htpvu 