### PR TITLE
Add workaround for Travis failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: node_js
 node_js:
   - "6"
 
-sudo: false
-dist: trusty
+sudo: required
 
 addons:
   chrome: stable


### PR DESCRIPTION
# Overview
* Adds recommended [workaround](https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524) for Chrome failures due to meltdown patches at travis-CI

# How to test
* Look for the green "build passed" icon when Travis builds.