### PR TITLE
Add JHU data archive as a repo

### DIFF
--- a/app/components/remaining-repos.js
+++ b/app/components/remaining-repos.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 
 export default Component.extend({
-    allRepos: ["PMC", "NSF-PAR", "DOE-PAGES", "JHU-IR"],
+    allRepos: ["PMC", "NSF-PAR", "DOE-PAGES", "JHU-IR", "JHU-AR"],
     addedDeposits: [],
     linkedDeposits: [],
 

--- a/app/helpers/repo-name.js
+++ b/app/helpers/repo-name.js
@@ -4,7 +4,8 @@ export function repoName([repo]) {
   let repoMap = {
     "PMC": "PubMed Central",
     "NSF-PAR": "National Science Foundation Public Access Repository",
-    "JHU-IR": "JScholarship - JHU Publications Repository"
+    "JHU-IR": "JScholarship - JHU Publications Repository",
+    "JHU-AR": "JHU Data Archive"
   };
 
   if (typeof repo !== 'string') {


### PR DESCRIPTION
# Overview
* Adds a "JHU Data Archive" option when selecting repositories

# How to test
* Check out this PR locally 
  1.  Check out the latest `master` from pass-ember (e.g. `git checkout master` then `git pull`)
  2.  Create a branch from master to try it out in : `git checkout -b birkland-jhu-archive master`
  3.  Pull the PR into it `git pull https://github.com/birkland/pass-ember.git jhu-archive`
  4.  Do `npm install` and then `ember serve`
* Go through the submission workflow until you see "repositories" step.  Verify that "JHU Data Archive is present, and that it can be added to the list of repositories to deposit to"

Interested Parties: @htpvu 
