### PR TITLE
Make rootURL available to all pages

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,6 +1,8 @@
 import Controller from '@ember/controller';
+import config from '../config/environment'
 
 export default Controller.extend({
+  rootURL: config.rootURL,
   actions: {
     logout() {
       this.get('session').logout();


### PR DESCRIPTION
Closes issue #44 
Added rootURL environment variable as extension to default Controller so that it could be used to form the logo path on any page. Previously the logo was only working on paths with one subfolder because `src="logo.png"` was sufficient to find the image in the root directory. Navigating to sub-folders as in `/grants/1` was causing the relative path to fail (../logo.png would have been required).