### PR TITLE
Adds optional-link helper and removes fake COEUS URIs

### DIFF
--- a/app/helpers/optional-link.js
+++ b/app/helpers/optional-link.js
@@ -1,0 +1,22 @@
+import { helper } from '@ember/component/helper';
+
+// pass in label followed by URI as parameters. This will check for a URL, if there
+// is one a link is created, if not it will just return the label
+
+function optionalLink(params) {
+  let label = params[0];
+  let url = params[1];
+  if (url!=null && url.trim().length>0) {
+	var a = document.createElement('a');
+	var linkText = document.createTextNode(label);
+	a.appendChild(linkText);
+	a.href = url;
+	a.title = url;
+	a.target = "_blank";
+    return a;
+  } else {
+    return label;
+  }
+}
+
+export default helper(optionalLink);

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -66,69 +66,55 @@ export default Route.extend({
     });
 
     let coeus1 = store.createRecord('identifier', {
-        label: '16129769',
-        uri: 'http://www.library.jhu.edu'
+        label: '16129769'
     });
 
     let coeus2 = store.createRecord('identifier', {
-        label: '16120629',
-         uri: 'http://www.jhu.edu'
+        label: '16120629'
     });
 
     let coeus3 = store.createRecord('identifier', {
-        label: '16120539',
-        uri: 'http://johnshopkins.edu'
+        label: '16120539'
     });
     let coeus4 = store.createRecord('identifier', {
-        label: '16120469',
-        uri: 'http://www.library.jhu.edu'
+        label: '16120469'
     });
 
     let coeus5 = store.createRecord('identifier', {
-        label: '16120459',
-         uri: 'http://www.jhu.edu'
+        label: '16120459'
     });
 
     let coeus6 = store.createRecord('identifier', {
-        label: '16120169',
-        uri: 'http://johnshopkins.edu'
+        label: '16120169'
     });
     let coeus7 = store.createRecord('identifier', {
-        label: '1204023',
-        uri: 'http://www.library.jhu.edu'
+        label: '1204023'
     });
 
     let coeus8 = store.createRecord('identifier', {
-        label: '16119319',
-        uri: 'http://www.jhu.edu'
+        label: '16119319'
     });
 
     let coeus9 = store.createRecord('identifier', {
-        label: '16119219',
-        uri: 'http://johnshopkins.edu'
+        label: '16119219'
     });
     let coeus10 = store.createRecord('identifier', {
-        label: '16118979',
-        uri: 'http://www.library.jhu.edu'
+        label: '16118979'
     });
 
     let coeus11 = store.createRecord('identifier', {
-        label: '16108389',
-         uri: 'http://www.jhu.edu'
+        label: '16108389'
     });
 
     let coeus12 = store.createRecord('identifier', {
-        label: '16097079',
-        uri: 'http://johnshopkins.edu'
+        label: '16097079'
     });
     let coeus13 = store.createRecord('identifier', {
-        label: '16086889',
-        uri: 'http://johnshopkins.edu'
+        label: '16086889'
     });
 
     let coeus14 = store.createRecord('identifier', {
-        label: '16075399',
-        uri: 'http://johnshopkins.edu'
+        label: '16075399'
     });
 
 

--- a/app/templates/components/identifier-cell.hbs
+++ b/app/templates/components/identifier-cell.hbs
@@ -1,2 +1,2 @@
 {{! Create a link to the identifier uri anchored by the label}}
-<a target='_blank' href='{{get record (concat column.propertyName '.uri')}}'>{{get record (concat column.propertyName '.label')}}</a>
+{{optional-link (get record (concat column.propertyName '.label')) (get record (concat column.propertyName '.uri'))}}

--- a/app/templates/components/submissions-repoid-cell.hbs
+++ b/app/templates/components/submissions-repoid-cell.hbs
@@ -1,3 +1,3 @@
 {{#each record.deposits as |deposit index|}}
-{{if index ', '}}<a href='{{deposit.assignedId.uri}}'>{{deposit.assignedId.label}} ({{deposit.assignedId.type}})</a>
+{{if index ', '}}{{optional-link (concat deposit.assignedId.label ' (' deposit.assignedId.type ')') deposit.assignedId.uri}}
 {{/each}}

--- a/tests/integration/components/identifier-cell-nolink-test.js
+++ b/tests/integration/components/identifier-cell-nolink-test.js
@@ -1,0 +1,41 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('identifier-cell', 'Integration | Component | identifier cell nolink', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  this.set('column', {
+    propertyName: 'id'
+  });
+
+  this.set('record', {
+      id: {
+        label: 'foo'
+      }
+  });
+
+  this.render(hbs`{{identifier-cell record=record column=column}}`);
+  assert.equal(this.$().text().trim(), 'foo');
+
+  // Template block usage:
+
+  this.render(hbs`
+    {{#identifier-cell record=record column=column}}
+    {{/identifier-cell}}
+  `);
+  assert.equal(this.$().text().trim(), 'foo');
+  
+  //check empty uri works as well
+  this.set('record', {
+      id: {
+        label: 'foo',
+		uri:''
+      }
+  });
+
+  this.render(hbs`{{identifier-cell record=record column=column}}`);
+  assert.equal(this.$().text().trim(), 'foo');
+
+});


### PR DESCRIPTION
Closes #115
Closes #102 (now easily resolved using changes for 115)
- adds helper method "optional-link" that uses a uri and label param to determine whether an `<a href...` tag should be displayed. If a URI has not been defined or the field is there but empty, the identifier will show as plain text with no link. If a URI is present, it will convert the identifier to a link
- applies this helper to the "COEUS" and "Repo ID" columns so that empty URIs aren't hyperlinked
- removes fake COEUS URIs from data since no longer used
- adds tests to exercise the variations for the new helper 

_Note: code does not confirm whether it is a URL rather than just a URI._