### PR TITLE
Disable per-column filtering

### DIFF
--- a/app/templates/grants/index.hbs
+++ b/app/templates/grants/index.hbs
@@ -5,6 +5,7 @@
   columns=columns
   themeInstance=themeInstance
   showColumnsDropdown=false
+  useFilteringByColumns=false
   filteringIgnoreCase=true
   multipleColumnsSorting=false
   piSelected='piclick'

--- a/app/templates/submissions.hbs
+++ b/app/templates/submissions.hbs
@@ -5,6 +5,7 @@
   columns=columns
   themeInstance=themeInstance
   showColumnsDropdown=false
+  useFilteringByColumns=false
   filteringIgnoreCase=true
   multipleColumnsSorting=false
   authorSelected='authorclick'


### PR DESCRIPTION
See JIRA issue PASS-28

We still have a global filter box above the grants/submissions table, however, the filter boxes that had appeared above certain columns no longer appear.

![](https://i.imgur.com/y75BebC.png)